### PR TITLE
Add operators to compile with OCaml ≥ 4.00.0

### DIFF
--- a/smartPrint.ml
+++ b/smartPrint.ml
@@ -1,3 +1,6 @@
+external (|>) : 'a -> ('a -> 'b) -> 'b = "%revapply";;
+external ( @@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"
+
 (* Separators. *)
 module Break = struct
   (* A break can be a whitespace or a newline if the text has to be splited. *)


### PR DESCRIPTION
I've made also a patch to the opam package to ba able to use smart-print ASAP:
https://github.com/ocaml/opam-repository/pull/1505
